### PR TITLE
Throttle sync a bit more

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - **FIX**: Only collaborators and owners are allowed to issue commands.
 - **FIX**: Fix commands not working in pull request issue body.
+- **FIX**: Throttle sync command more in cases where the API is being hit quite hard.
 
 ## 1.2.0
 

--- a/label_bot/sync_labels.py
+++ b/label_bot/sync_labels.py
@@ -165,8 +165,8 @@ async def sync(event, gh, config):
                 print('    Skipping {}: #{} "{}"'.format(label['name'], label['color'], label['description']))
             updated.add(label['name'])
 
-        if (calls % 10) == 0:
-            await asyncio.sleep(10)
+        if (calls % 20) == 0:
+            await asyncio.sleep(30)
 
     for value in labels:
         name = value['name']
@@ -181,10 +181,10 @@ async def sync(event, gh, config):
                 accept=util.LABEL_HEADER
             )
             await asyncio.sleep(1)
-            call += 1
+            calls += 1
 
-            if (calls % 10) == 0:
-                await asyncio.sleep(10)
+            if (calls % 20) == 0:
+                await asyncio.sleep(30)
 
 
 async def pending(event, gh):

--- a/label_bot/sync_labels.py
+++ b/label_bot/sync_labels.py
@@ -130,11 +130,13 @@ async def sync(event, gh, config):
         return
 
     count = 0
+    calls = 1
     async for label in gh.getiter(event.labels_url, accept=util.LABEL_HEADER):
 
         count += 1
         if (count % 20) == 0:
             await asyncio.sleep(1)
+            calls += 1
 
         edit = _find_label(labels, label['name'], label['color'], label['description'])
         if edit is not None and edit.modified:
@@ -147,6 +149,7 @@ async def sync(event, gh, config):
             )
             updated.add(edit.old)
             updated.add(edit.new)
+            calls += 1
             await asyncio.sleep(1)
         else:
             if edit is None and delete and label['name'].lower() not in ignores:
@@ -156,10 +159,14 @@ async def sync(event, gh, config):
                     {'name': label['name']},
                     accept=util.LABEL_HEADER
                 )
+                calls += 1
                 await asyncio.sleep(1)
             else:
                 print('    Skipping {}: #{} "{}"'.format(label['name'], label['color'], label['description']))
             updated.add(label['name'])
+
+        if (calls % 10) == 0:
+            await asyncio.sleep(10)
 
     for value in labels:
         name = value['name']
@@ -174,6 +181,10 @@ async def sync(event, gh, config):
                 accept=util.LABEL_HEADER
             )
             await asyncio.sleep(1)
+            call += 1
+
+            if (calls % 10) == 0:
+                await asyncio.sleep(10)
 
 
 async def pending(event, gh):


### PR DESCRIPTION
Is 10 seconds for every 10 API calls enough? Should it be more?

@gir-bot needs-decision
@gir-bot  remove needs-review

