### PR TITLE
Consolidate duplicate code

### DIFF
--- a/label_bot/lgtm_labels.py
+++ b/label_bot/lgtm_labels.py
@@ -1,8 +1,6 @@
 """Looks good to me command."""
-import asyncio
 import traceback
 import sys
-from . import util
 
 
 async def run(event, gh, config):
@@ -18,11 +16,7 @@ async def run(event, gh, config):
         success = False
 
     if not success:
-        await gh.post(
-            event.issues_comments_url,
-            {"number": event.number},
-            data={"body": "Oops! There was a problem transitioning the issue."}
-        )
+        await event.post_comment(gh, 'Oops! There was a problem transitioning the issue.')
 
 
 async def lgtm(event, gh, config, **kwargs):
@@ -35,7 +29,7 @@ async def lgtm(event, gh, config, **kwargs):
     add = []
     remove = []
 
-    async for name in event.live_labels(gh):
+    async for name in event.get_issue_labels(gh):
         low = name.lower()
         if low in add_labels:
             del add_labels[low]
@@ -44,22 +38,5 @@ async def lgtm(event, gh, config, **kwargs):
 
     add = [x for x in add_labels.values()]
 
-    count = 0
-    for label in remove:
-        count += 1
-        if (count % 2) == 0:
-            await asyncio.sleep(1)
-
-        await gh.delete(
-            event.issue_labels_url,
-            {'number': event.number, 'name': label},
-            accept=util.LABEL_HEADER
-        )
-
-    if add:
-        await gh.post(
-            event.issue_labels_url,
-            {'number': event.number},
-            data={'labels': add},
-            accept=util.LABEL_HEADER
-        )
+    await event.remove_issue_labels(gh, remove)
+    await event.add_issue_labels(gh, add)

--- a/label_bot/wip_labels.py
+++ b/label_bot/wip_labels.py
@@ -1,7 +1,7 @@
 """Handle work in progress labels."""
-import os
 import sys
 import traceback
+from . import util
 
 DEFAULT = ('wip', 'work in progress', 'work-in-progress')
 
@@ -13,20 +13,16 @@ async def wip(event, gh, config):
     wip_list = set([label.lower() for label in config.get('wip', DEFAULT)])
 
     # Grab the labels in this issue event.
-    async for name in event.live_labels(gh):
+    async for name in event.get_issue_labels(gh):
         if name.lower() in wip_list:
             wip = True
             break
 
-    await gh.post(
-        event.statuses_url,
-        {'sha': event.sha},
-        data={
-            "state": "pending" if wip else "success",
-            "target_url": "https://github.com/gir-bot/label-bot",
-            "description": "Work in progress" if wip else "Ready for review",
-            "context": "{}/labels/wip".format(os.environ.get("GH_BOT"))
-        }
+    await event.set_status(
+        gh,
+        util.EVT_PENDING if wip else util.EVT_SUCCESS,
+        'labels/wip',
+        "Work in progress" if wip else "Ready for review"
     )
 
 
@@ -43,13 +39,9 @@ async def run(event, gh, config, **kwargs):
         fail = True
 
     if fail:
-        await gh.post(
-            event.statuses_url,
-            {'sha': event.sha},
-            data={
-                "state": "failure",
-                "target_url": "https://github.com/gir-bot/label-bot",
-                "description": "Failed to complete",
-                "context": "{}/labels/wip".format(os.environ.get("GH_BOT"))
-            }
+        await event.set_status(
+            gh,
+            util.EVT_FAILURE,
+            'labels/wip',
+            'Failed to complete task'
         )


### PR DESCRIPTION
Move label manipulation code to the Event object to help consolidate
duplicate code.

For commands, which don't use Event objects, consolidate to a common
function.