### PR TITLE
Improve sync logic and catch failures if label already exists or not

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## 1.4.1
 
 - **FIX**: Labels that were renamed are not always detected as renamed.
+- **FIX**: Better logic to avoid adding a label that already exists or removing a label that does not exist. Also,
+  detect such failures if we do run into such scenarios, and don't fail the sync.
 
 ## 1.4.0
 


### PR DESCRIPTION
Improve logic to better avoid adding a label or removing a label that
respectively already exists or doesn't exist. In the case that somehow
we still make such an attempt (labels change behind the scene) don't
fail the sync process.